### PR TITLE
Don't add input only windows in setup()

### DIFF
--- a/frankenwm.c
+++ b/frankenwm.c
@@ -2119,8 +2119,10 @@ int setup(int default_screen)
                             xcb_get_window_attributes(dis, children[i]), NULL);
             if (!attr)
                 continue;
-            /* ignore windows in override redirect mode as we won't see them */
-            if (!attr->override_redirect) {
+            /* ignore windows in override redirect mode or with input only
+             * class as we won't see them */
+            if (!attr->override_redirect
+                && attr->_class != XCB_WINDOW_CLASS_INPUT_ONLY) {
                 addwindow(children[i]);
                 grabbuttons(wintoclient(children[i]));
             }


### PR DESCRIPTION
Input-only windows are supposed to be invisible, and therefore shouldn't get a client in FrankenWM. Without this fix, I get an empty, windowless client in my layout on startup.