### PR TITLE
Don't removeclient when sending WM_DELETE_WINDOW

### DIFF
--- a/frankenwm.c
+++ b/frankenwm.c
@@ -1209,9 +1209,10 @@ void killclient()
     }
     if (got)
         deletewindow(current->win);
-    else
+    else {
         xcb_kill_client(dis, current->win);
-    removeclient(current);
+        removeclient(current);
+    }
 }
 
 /* focus the previously focused desktop */


### PR DESCRIPTION
A client shouldn't be immediately removed in killclient() if its window supports the WM_DELETE_WINDOW protocol, since some applications that support this protocol do so in order to prompt the user for input before closing ("Are you sure you want to quit?"). The windows and clients will be cleaned up later when the appropriate event is received.