### PR TITLE
remove clients on window unmap

### DIFF
--- a/frankenwm.c
+++ b/frankenwm.c
@@ -2426,7 +2426,7 @@ void unmapnotify(xcb_generic_event_t *e)
 {
     xcb_unmap_notify_event_t *ev = (xcb_unmap_notify_event_t *)e;
     client *c = wintoclient(ev->window);
-    if (c && ev->event != screen->root)
+    if (c)
         removeclient(c);
     desktopinfo();
 }


### PR DESCRIPTION
unmapnotify was not invoking removeclient for windows whose parents were the
root window, causing desktopinfo to use outdated information. I don't see any
reason clients whose windows are children of the root window should not be
removed when unmapped.