### PR TITLE
Improve scratchpad handling in cleanup

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -32,6 +32,7 @@
 #define AUTOCENTER      True      /* automatically center windows floating by default */
 #define OUTPUT_TITLE    False     /* output the title of the currently active window */
 #define USE_SCRATCHPAD  False     /* enable the scratchpad functionality */
+#define CLOSE_SCRATCHPAD True     /* close scratchpad on quit */
 #define SCRPDNAME       "scratchpad" /* the name of the scratchpad window */
 
 /*

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -568,6 +568,19 @@ void cleanup(void)
     xcb_query_tree_reply_t *query;
     xcb_window_t *c;
 
+    if(USE_SCRATCHPAD && scrpd) {
+        if(CLOSE_SCRATCHPAD) {
+            deletewindow(scrpd->win);
+        }
+        else {
+            xcb_get_geometry_reply_t *wa = get_geometry(scrpd->win);
+            xcb_move(dis, scrpd->win, (ww - wa->width) / 2, (wh - wa->height) / 2);
+            free(wa);
+        }
+        free(scrpd);
+        scrpd = NULL;
+    }
+
     xcb_key_symbols_free(keysyms);
 
     xcb_ungrab_key(dis, XCB_GRAB_ANY, screen->root, XCB_MOD_MASK_ANY);


### PR DESCRIPTION
In cleanup(); delete the scratchpad or move the window to visible area.
Then free(); the client structure.