### PR TITLE
Scratchpad focus follows mouse issue

### DIFF
--- a/frankenwm.c
+++ b/frankenwm.c
@@ -2484,7 +2484,7 @@ void update_current(client *newfocus)   // newfocus may be NULL
         }
     }
 
-    if(!current && (USE_SCRATCHPAD && showscratchpad && scrpd))             // focus scratchpad, if visible
+    if(!current && (USE_SCRATCHPAD && showscratchpad && scrpd))     // focus scratchpad, if visible
         current = scrpd;
 
     if(!current) {  // there is really really really nothing to focus.
@@ -2492,6 +2492,8 @@ void update_current(client *newfocus)   // newfocus may be NULL
         return;
     }
 
+
+    client *c;
     /* num of n:all fl:fullscreen ft:floating/transient windows */
     int n = 0, fl = 0, ft = 0;
     for (c = head; c; c = c->next, ++n)


### PR DESCRIPTION
when use focus-follows-mouse, and scratchpad loses focus, it did not get focus again until togglescratchpad(); , because wintoclient(); does not return the scratchpad window-id.
----
enternotify(); now checks if the event-window is scratchpad, then calls update_current(); to scratchpad window-id.

also hardened update_current(); a bit

in change_desktop(); there's imho no reason to unmap the scratchpad. Simply raise it after map the new windows should be sufficient.