### PR TITLE
Fix: Issue 31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MANPREFIX = ${PREFIX}/share/man
 INCS = -I. -I${PREFIX}/include -I/usr/X11R6/include
 LIBS = -lc -lX11 `pkg-config --libs xcb xcb-icccm xcb-keysyms xcb-ewmh`
 
-CPPFLAGS += -g -DDEBUGGING -DVERSION=\"${VERSION}\" -DWMNAME=\"${WMNAME}\"
+CPPFLAGS += -DVERSION=\"${VERSION}\" -DWMNAME=\"${WMNAME}\"
 
 DEBUG 	 = 0
 CFLAGS   += -std=c99 -pedantic -Wall -Wextra -Os ${INCS} ${CPPFLAGS} -DVERSION=\"${VERSION}\" 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LIBS = -lc -lX11 `pkg-config --libs xcb xcb-icccm xcb-keysyms xcb-ewmh`
 CPPFLAGS += -DVERSION=\"${VERSION}\" -DWMNAME=\"${WMNAME}\"
 
 DEBUG 	 = 0
-CFLAGS   += -std=c99 -pedantic -Wall -Wextra -Os ${INCS} ${CPPFLAGS} -DVERSION=\"${VERSION}\" 
+CFLAGS   += -DDEBUGGING -std=c99 -pedantic -Wall -Wextra -Os ${INCS} ${CPPFLAGS} -DVERSION=\"${VERSION}\" 
 LDFLAGS  += ${LIBS}
 
 EXEC = ${WMNAME}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MANPREFIX = ${PREFIX}/share/man
 INCS = -I. -I${PREFIX}/include -I/usr/X11R6/include
 LIBS = -lc -lX11 `pkg-config --libs xcb xcb-icccm xcb-keysyms xcb-ewmh`
 
-CPPFLAGS += -DVERSION=\"${VERSION}\" -DWMNAME=\"${WMNAME}\"
+CPPFLAGS += -g -DDEBUGGING -DVERSION=\"${VERSION}\" -DWMNAME=\"${WMNAME}\"
 
 DEBUG 	 = 0
 CFLAGS   += -std=c99 -pedantic -Wall -Wextra -Os ${INCS} ${CPPFLAGS} -DVERSION=\"${VERSION}\" 


### PR DESCRIPTION
I catch self-mapped windows in eventnotify();
later raise them in update_current();

At the moment, only "_NET_WM_WINDOW_TYPE_NOTIFICATION" windows are handled.
Future will show if we also have to take care for "_NET_WM_WINDOW_TYPE_UTILITY".

There's a -DDEBUGGING define in Makefile, pls remove after merging.

