### PR TITLE
no borders fix

### DIFF
--- a/frankenwm.c
+++ b/frankenwm.c
@@ -2436,6 +2436,7 @@ int setup(int default_screen)
              * class as we won't see them */
             if (!attr->override_redirect
                 && attr->_class != XCB_WINDOW_CLASS_INPUT_ONLY) {
+                client *c;
                 uint32_t dsk = cd;
                 int haddsk;
 
@@ -2469,7 +2470,9 @@ int setup(int default_screen)
                 }
                 if (cd != dsk)
                     select_desktop(dsk);
-                addwindow(children[i]);
+                c = addwindow(children[i]);
+                if (c)
+                    c->borderwidth = -1;
                 grabbuttons(wintoclient(children[i]));
                 if (cd != dsk) {
                     xcb_unmap_window(dis, children[i]);


### PR DESCRIPTION
issue: when restarting FrankenWM, existing windows would not get borders.

reason: because c->borderwidth is still on initial value zero, after setup();   client_borders(); returns zero.

fix: set c->borderwidth to -1 in setup();

todo?: add code to respect custom widths here, as in maprequest();