### PR TITLE
New: Wm_Take_Focus support

### DIFF
--- a/frankenwm.c
+++ b/frankenwm.c
@@ -726,13 +726,18 @@ void centerwindow(void)
 /* remove all windows in all desktops by sending a delete message */
 void cleanup(void)
 {
+/*
     xcb_query_tree_reply_t *query;
     xcb_window_t *c;
+*/
+    client *c;
+    
     if(USE_SCRATCHPAD && scrpd) {
         if(CLOSE_SCRATCHPAD) {
             deletewindow(scrpd->win);
         }
         else {
+            xcb_border_width(dis, scrpd->win, 0);
             xcb_get_geometry_reply_t *wa = get_geometry(scrpd->win);
             xcb_move(dis, scrpd->win, (ww - wa->width) / 2, (wh - wa->height) / 2);
             free(wa);
@@ -753,6 +758,9 @@ void cleanup(void)
         free(query);
     }
 */
+    for (c = head; c; c = c->next)
+        xcb_border_width(dis, c->win, 0);
+
     xcb_ewmh_connection_wipe(ewmh);
     free(ewmh);
 

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -1466,13 +1466,13 @@ void mapnotify(xcb_generic_event_t *e)
 			if(!(wintoalien(&alienlist, ev->window))) {
 				alien *a;
 
-                DEBUG("caught a new selfmapping ABOVE window");
+                DEBUG("caught a new selfmapped window");
 				if((a = create_alien(ev->window))) {
 					add_tail(&alienlist, (node *)a);
                 }
 			}
             else {
-				DEBUG("_NET_WM_STATE_ABOVE already in list");
+				DEBUG("selfmapped window already in list");
             }
         }
         if(attr[0])

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -156,6 +156,9 @@ typedef struct {
  * istransient is separate from isfloating as floating window can be reset
  * to their tiling positions, while the transients will always be floating
  */
+/*
+ * Developer reminder: do not forget to update sanedefaults();
+ */
 typedef struct client {
     struct client *next;
     bool isurgent, istransient, isfullscrn, isfloating, isminimized;

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -735,7 +735,6 @@ void cleanup(void)
     xcb_query_tree_reply_t *query;
     xcb_window_t *c;
 */
-    client *c;
     
     if(USE_SCRATCHPAD && scrpd) {
         if(CLOSE_SCRATCHPAD) {
@@ -751,9 +750,6 @@ void cleanup(void)
         scrpd = NULL;
     }
 
-    xcb_key_symbols_free(keysyms);
-    xcb_ungrab_key(dis, XCB_GRAB_ANY, screen->root, XCB_MOD_MASK_ANY);
-
 /*
     if ((query = xcb_query_tree_reply(dis,
                                       xcb_query_tree(dis, screen->root), 0))) {
@@ -763,8 +759,6 @@ void cleanup(void)
         free(query);
     }
 */
-    for (c = head; c; c = c->next)
-        xcb_border_width(dis, c->win, 0);
 
     xcb_ewmh_connection_wipe(ewmh);
     free(ewmh);
@@ -783,6 +777,7 @@ void cleanup(void)
 
         for (client *c = desktops[i].head, *c_next; c; c = c_next) {
             c_next = c->next;
+            xcb_border_width(dis, c->win, 0);
             free(c);
         }
     }
@@ -3041,6 +3036,7 @@ int main(int argc, char *argv[])
         run();
     }
     cleanup();
+    xcb_flush(dis);
     xcb_disconnect(dis);
     ungrab_focus();
     return retval;

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -2920,11 +2920,11 @@ void update_current(client *newfocus)   // newfocus may be NULL
 
     if (current) {
         if (current->setfocus) {
-            xcb_set_input_focus(dis, XCB_INPUT_FOCUS_POINTER_ROOT, current->win,
-                                XCB_CURRENT_TIME);
         xcb_change_property(dis, XCB_PROP_MODE_REPLACE, screen->root,
                             netatoms[NET_ACTIVE], XCB_ATOM_WINDOW, 32, 1,
                             &current->win);
+        xcb_set_input_focus(dis, XCB_INPUT_FOCUS_POINTER_ROOT, current->win,
+                            XCB_CURRENT_TIME);
         DEBUG("xcb_set_input_focus();");
         }
         else {

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -1417,14 +1417,15 @@ void keypress(xcb_generic_event_t *e)
 void killclient()
 {
     if (!deletewindow(current->win)) {
-        DEBUG("client killed");
         xcb_kill_client(dis, current->win);
-        removeclient(current);
+        DEBUG("client killed");
     }
     else {
         DEBUG("client deleted");
     }
+    removeclient(current);
 }
+
 static bool check_wmproto(xcb_window_t win, xcb_atom_t proto)
 {
     xcb_icccm_get_wm_protocols_reply_t reply;

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -728,7 +728,6 @@ void cleanup(void)
 {
     xcb_query_tree_reply_t *query;
     xcb_window_t *c;
-
     if(USE_SCRATCHPAD && scrpd) {
         if(CLOSE_SCRATCHPAD) {
             deletewindow(scrpd->win);
@@ -745,6 +744,7 @@ void cleanup(void)
     xcb_key_symbols_free(keysyms);
     xcb_ungrab_key(dis, XCB_GRAB_ANY, screen->root, XCB_MOD_MASK_ANY);
 
+/*
     if ((query = xcb_query_tree_reply(dis,
                                       xcb_query_tree(dis, screen->root), 0))) {
         c = xcb_query_tree_children(query);
@@ -752,6 +752,7 @@ void cleanup(void)
             deletewindow(c[i]);
         free(query);
     }
+*/
     xcb_ewmh_connection_wipe(ewmh);
     free(ewmh);
 
@@ -1598,6 +1599,7 @@ void maprequest(xcb_generic_event_t *e)
         select_desktop(newdsk);
     client *c = addwindow(ev->window);
 
+    c->setfocus = True;
     xcb_icccm_wm_hints_t hints;
     if (xcb_icccm_get_wm_hints_reply(dis,
         xcb_icccm_get_wm_hints(dis, ev->window), &hints, NULL))

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -2914,17 +2914,23 @@ void update_current(client *newfocus)   // newfocus may be NULL
 
     if (check_head(&alienlist)) {
         alien *a;
-
         for(a=(alien *)get_head(&alienlist); a; a=(alien *)get_next((node *)a))
             xcb_raise_window(dis, a->win);
     }
 
-    if(current) {
+    if (current) {
+        if (current->setfocus) {
+            xcb_set_input_focus(dis, XCB_INPUT_FOCUS_POINTER_ROOT, current->win,
+                                XCB_CURRENT_TIME);
         xcb_change_property(dis, XCB_PROP_MODE_REPLACE, screen->root,
                             netatoms[NET_ACTIVE], XCB_ATOM_WINDOW, 32, 1,
                             &current->win);
-        xcb_set_input_focus(dis, XCB_INPUT_FOCUS_POINTER_ROOT, current->win,
-                            XCB_CURRENT_TIME);
+        DEBUG("xcb_set_input_focus();");
+        }
+        else {
+            sendevent(current->win, wmatoms[WM_TAKE_FOCUS]);
+            DEBUG("send WM_TAKE_FOCUS");
+        }
     }
 }
 


### PR DESCRIPTION
first, I've made the doubly linked functions more bullet proof.
then prepared the code for WM_TAKE_FOCUS protocol.
then added WM_TAKE_FOCUS support.
also added sanedefaults(); function, to fill in initial defaults right after calloc(client);
note: from now on, we should be able to use malloc instead of calloc();, thanks to sanedefaults();

also: there is no need for deletewindow(); loop in cleanup();

todo: I try to reset the window-borders in cleanup();, but for some reason I did not yet figure out yet, this does not yet work, except scratchpad.