### PR TITLE
Remove borders on quit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINDIR ?= ${PREFIX}/bin
 MANPREFIX = ${PREFIX}/share/man
 
 INCS = -I. -I${PREFIX}/include -I/usr/X11R6/include
-LIBS = -lc -lX11 `pkg-config --libs xcb xcb-icccm xcb-keysyms xcb-ewmh`
+LIBS = -lc -lX11 `pkg-config --libs xcb xcb-aux xcb-icccm xcb-keysyms xcb-ewmh`
 
 CFLAGS   += -std=c99 -pedantic -Wall -Wextra -Os ${INCS} ${CPPFLAGS}
 LDFLAGS  += ${LIBS}

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -13,6 +13,7 @@
 #include <X11/keysym.h>
 #include <xcb/xcb.h>
 #include <xcb/xcb_atom.h>
+#include <xcb/xcb_aux.h>
 #include <xcb/xcb_icccm.h>
 #include <xcb/xcb_keysyms.h>
 #include <xcb/xcb_ewmh.h>
@@ -3026,7 +3027,8 @@ int main(int argc, char *argv[])
         run();
     }
     cleanup();
-    xcb_flush(dis);
+//    xcb_flush(dis);
+    xcb_aux_sync(dis);
     xcb_disconnect(dis);
     ungrab_focus();
     return retval;

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -3027,7 +3027,6 @@ int main(int argc, char *argv[])
         run();
     }
     cleanup();
-//    xcb_flush(dis);
     xcb_aux_sync(dis);
     xcb_disconnect(dis);
     ungrab_focus();


### PR DESCRIPTION
Issue: Until now, borders were set to zero, but xcb_flush(); was either too slow or whatever, and xcb_diconnect(); cancelled the borders commands.

Solution: call xcb_aux_sync(); instead xcb_flush();
