### PR TITLE
Maprequest issue

### DIFF
--- a/frankenwm.c
+++ b/frankenwm.c
@@ -1558,9 +1558,9 @@ void maprequest(xcb_generic_event_t *e)
             xcb_atom_t a = type.atoms[i];
             if (a == ewmh->_NET_WM_WINDOW_TYPE_TOOLBAR || a == ewmh->_NET_WM_WINDOW_TYPE_DOCK) {
                 alien *utility;
+                xcb_ewmh_get_atoms_reply_wipe(&type);
                 if((utility = create_alien(ev->window)))
                     add_tail(&alienlist, (node *)utility);
-                xcb_ewmh_get_atoms_reply_wipe(&type);
                 xcb_map_window(dis, ev->window);
                 return;
             }


### PR DESCRIPTION
FrankenWM should map all windows in maprequest();
I realized that when messing around with my fspanel fork.
Original fspanel did not set WINDOW_TYPE_DOCK property, then the window was mapped.
As soon as I added support for WINDOW_TYPE_DOCK property in fspanel, the window was not mapped anymore.
Also override_redirect windows must be mapped, else the icons and sub-windows won't be visible.

To those interested: https://github.com/t4nkw4rt/fspanel