### PR TITLE
Weekend Development

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -36,6 +36,7 @@
 #define USE_SCRATCHPAD  False     /* enable the scratchpad functionality */
 #define CLOSE_SCRATCHPAD True     /* close scratchpad on quit */
 #define SCRPDNAME       "scratchpad" /* the name of the scratchpad window */
+#define EWMH_TASKBAR    True      /* False if text (or no) panel/taskbar */
 
 /*
  * EDIT THIS: applicaton specific rules

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -687,7 +687,7 @@ void change_desktop(const Arg *arg)
  */
 static void centerfloating(client *c)
 {
-    if (!c || !current->isfloating)
+    if (!c || !c->isfloating)
         return;
 
     xcb_get_geometry_reply_t *wa;
@@ -698,7 +698,7 @@ static void centerfloating(client *c)
 }
 
 /*
- * centerclient(); wrapper
+ * centerfloating(); wrapper
  */
 void centerwindow(void)
 {

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -1473,27 +1473,27 @@ void mapnotify(xcb_generic_event_t *e)
 
     if (wintoclient(ev->window) || (scrpd && scrpd->win == ev->window))
         return;
-    else {
-        xcb_window_t windows[] = {ev->window};
-        xcb_get_window_attributes_reply_t *attr[1];
 
-        xcb_get_attributes(windows, attr, 1);
-        if (!attr[0] || attr[0]->override_redirect) {
-            if(!(wintoalien(&alienlist, ev->window))) {
-                alien *a;
+    xcb_window_t wins[] = {ev->window};
+    xcb_get_window_attributes_reply_t *attr[1];
 
+    xcb_get_attributes(wins, attr, 1);
+    if (!attr[0])
+        return;     /* dead on arrival */
+    if (attr[0]->override_redirect) {
+        if (!(wintoalien(&alienlist, ev->window))) {
+            alien *a;
+            if ((a = create_alien(ev->window))) {
+                xcb_raise_window(dis, ev->window);
                 DEBUG("caught a new selfmapped window");
-                if((a = create_alien(ev->window))) {
-                    add_tail(&alienlist, (node *)a);
-                }
+                add_tail(&alienlist, (node *)a);
             }
             else {
-                DEBUG("selfmapped window already in list");
+                DEBUG("alien window already in list");
             }
         }
-        if(attr[0])
-            free(attr[0]);
     }
+    free(attr[0]);
 }
 
 /* a map request is received when a window wants to display itself

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -901,12 +901,18 @@ void clientmessage(xcb_generic_event_t *e)
             if (c && ev->type == ewmh->_NET_CLOSE_WINDOW)
                 removeclient(c);
             else {
-                if (c && ev->type == ewmh->_NET_ACTIVE_WINDOW) {
-                    client *t = NULL;
-                    for (t = head; t && t != c; t = t->next)
-                        ;
-                    if (t)
-                        update_current(c);
+                if (ev->type == ewmh->_NET_ACTIVE_WINDOW) {
+                    if (c) {
+                        client *t = NULL;
+                        for (t = head; t && t != c; t = t->next)
+                            ;
+                        if (t)
+                            update_current(c);
+                    }
+                    else {
+                        if (showscratchpad && scrpd && scrpd->win == ev->window)
+                            update_current(scrpd);
+                    }
                 }
                 else {
                     if (c && ev->type == ewmh->_NET_WM_DESKTOP

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -2223,7 +2223,7 @@ void resize_y(const Arg *arg)
     free(r);
 }
 
-/* get the last client from the current miniq and restore it */
+/* get (the last) client from the current miniq and restore it */
 void restore_client(client *c)
 {
     lifo *tmp;
@@ -2231,10 +2231,24 @@ void restore_client(client *c)
     if (!miniq[current_desktop])
         return;
 
-/* TODO: find certain client in miniq */
+    if (c == NULL) {
+        tmp = miniq[current_desktop];
+        miniq[current_desktop] = miniq[current_desktop]->next;
+    }
+    else {
+        lifo *prev = NULL;
 
-    tmp = miniq[current_desktop];
-    miniq[current_desktop] = miniq[current_desktop]->next;
+        for(tmp = miniq[current_desktop]; tmp; tmp = tmp->next) {
+            if (tmp->c == c) {
+                if (prev)
+                    prev->next = tmp->next;
+                else
+                    miniq[current_desktop] = tmp->next;
+                break;
+            }
+            prev = tmp;
+        }
+    }
 
     tmp->c->isminimized = false;
     xcb_remove_property(dis, tmp->c->win, ewmh->_NET_WM_STATE, ewmh->_NET_WM_STATE_HIDDEN);


### PR DESCRIPTION
There are quite some improvements since my last commit:
- Check if client DESKTOP prop is not > DESKTOPS, else move client to last desktop.

- remove the unneeded netatoms[ATOM] variable. Now use only ewmh->ATOM.

- improve clientmessage();

- add EWMH_TASKBAR to config.def.h
  True: there is something like fspanel, tint2 or lxpanel running.
  False: use no any panel at all, or no ewmh compatible panel.

- add _EWMH_CLIENT_LIST support.  This code is inside #ifdef / #endif, so the codesize will not increase at all if person sets EWMH_TASKBAR = False.

- fixed _NET_WM_WINDOW_TYPE_DIALOG clients. (my mistake)

- configurerequest(); now only checks _NET_WM_WINDOW_TYPE_NORMAL against boundaries.
  for example, a panel that tries to move itself to 0/0 would instead be moved to 0/PANELHEIGHT.

clientmessage(ACTIVE_WINDOW); now also checks for scratchpad.

_NET_WM_STATE_HIDDEN support

changed miniq First-In Last-Out to Last-In First Out.
Reason: much easier code. All we have to do now is check/add/remove the head of the list. And no need for an empty terminator in the miniq.
