### PR TITLE
Imp hidden prop

### DIFF
--- a/frankenwm.c
+++ b/frankenwm.c
@@ -2669,7 +2669,7 @@ int setup(int default_screen)
                     free(prop_reply);
                 }
 
-/*              
+/*
  * case 1: window has no desktop property and is unmapped --> ignore
  * case 2: window has no desktop property and is mapped --> add desktop property and append to client list.
  * case 3: window has current desktop property and is unmapped --> map and append to client list.

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -2683,26 +2683,26 @@ int setup(int default_screen)
                 if (!(xcb_ewmh_get_wm_desktop_reply(ewmh,
                       xcb_ewmh_get_wm_desktop(ewmh, children[i]), &dsk, NULL))) {
                     if (attr->map_state == XCB_MAP_STATE_UNMAPPED)
-                        continue;                                                   /* case 1 */
+                        continue;                                               /* case 1 */
                     else
-                        xcb_ewmh_set_wm_desktop(ewmh, children[i], dsk = cd);       /* case 2 */
+                        xcb_ewmh_set_wm_desktop(ewmh, children[i], dsk = cd);   /* case 2 */
                 }
                 else {
                     if (isHidden)
-                        doMinimize = True;                                          /* case 4 */
+                        doMinimize = True;                                      /* case 4 */
                     if ((int)dsk > DESKTOPS-1)
                         xcb_ewmh_set_wm_desktop(ewmh, children[i], dsk = DESKTOPS-1);   /* case 8 */
                     if (dsk == cd) {
                         if (attr->map_state == XCB_MAP_STATE_UNMAPPED)                  
-                            xcb_map_window(dis, children[i]);                       /* case 3 */
+                            xcb_map_window(dis, children[i]);                   /* case 3 */
                         else    
-                            { ; }                                                   /* case 5 */
+                            { ; }                                               /* case 5 */
                     }
                     else {  /* different desktop */
                         if (attr->map_state == XCB_MAP_STATE_UNMAPPED)
-                            { ; }                                                   /* case 6 */
+                            { ; }                                               /* case 6 */
                         else
-                            xcb_unmap_window(dis, children[i]);                     /* case 7 */
+                            xcb_unmap_window(dis, children[i]);                 /* case 7 */
                     }
                 }
                 if (cd != dsk)

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -2683,26 +2683,26 @@ int setup(int default_screen)
                 if (!(xcb_ewmh_get_wm_desktop_reply(ewmh,
                       xcb_ewmh_get_wm_desktop(ewmh, children[i]), &dsk, NULL))) {
                     if (attr->map_state == XCB_MAP_STATE_UNMAPPED)
-                        continue;                                                       /* case 1 */
+                        continue;                                                   /* case 1 */
                     else
-                        xcb_ewmh_set_wm_desktop(ewmh, children[i], dsk = cd);           /* case 2 */
+                        xcb_ewmh_set_wm_desktop(ewmh, children[i], dsk = cd);       /* case 2 */
                 }
                 else {
                     if (isHidden)
-                        doMinimize = True;                                              /* case 4 */
+                        doMinimize = True;                                          /* case 4 */
                     if ((int)dsk > DESKTOPS-1)
                         xcb_ewmh_set_wm_desktop(ewmh, children[i], dsk = DESKTOPS-1);   /* case 8 */
                     if (dsk == cd) {
                         if (attr->map_state == XCB_MAP_STATE_UNMAPPED)                  
-                            xcb_map_window(dis, children[i]);                           /* case 3 */
+                            xcb_map_window(dis, children[i]);                       /* case 3 */
                         else    
-                            { ; }                                                       /* case 5 */
+                            { ; }                                                   /* case 5 */
                     }
                     else {  /* different desktop */
                         if (attr->map_state == XCB_MAP_STATE_UNMAPPED)
-                            { ; }                                                       /* case 6 */
+                            { ; }                                                   /* case 6 */
                         else
-                            xcb_unmap_window(dis, children[i]);                         /* case 7 */
+                            xcb_unmap_window(dis, children[i]);                     /* case 7 */
                     }
                 }
                 if (cd != dsk)

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -2691,7 +2691,7 @@ int setup(int default_screen)
                     if (isHidden)
                         doMinimize = True;                                      /* case 4 */
                     if ((int)dsk > DESKTOPS-1)
-                        xcb_ewmh_set_wm_desktop(ewmh, children[i], dsk = DESKTOPS-1);   /* case 8 */
+                        xcb_ewmh_set_wm_desktop(ewmh, children[i], dsk = DESKTOPS-1);  /* case 8 */
                     if (dsk == cd) {
                         if (attr->map_state == XCB_MAP_STATE_UNMAPPED)                  
                             xcb_map_window(dis, children[i]);                   /* case 3 */

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -2673,15 +2673,13 @@ int setup(int default_screen)
  * case 1: window has no desktop property and is unmapped --> ignore
  * case 2: window has no desktop property and is mapped --> add desktop property and append to client list.
  * case 3: window has current desktop property and is unmapped --> map and append to client list.
- * case 4: window has HIDDEN property -> move to miniq and append to client list.
+ * case 4: window has desktop and hidden property -> move to miniq and append to client list.
  * case 5: window has current desktop property and is mapped  --> append to client list.
  * case 6: window has different desktop property and is unmapped -> append to client list.
  * case 7: window has different desktop property and is mapped -> unmap and append to client list.
  * case 8: window has desktop property > DESKTOPS -> move window to last desktop
  * case 9: window has desktop property = -1 -> TODO: sticky window support.
  */
-                if (isHidden)
-                    doMinimize = True;                                                  /* case 4 */
                 if (!(xcb_ewmh_get_wm_desktop_reply(ewmh,
                       xcb_ewmh_get_wm_desktop(ewmh, children[i]), &dsk, NULL))) {
                     if (attr->map_state == XCB_MAP_STATE_UNMAPPED)
@@ -2690,6 +2688,8 @@ int setup(int default_screen)
                         xcb_ewmh_set_wm_desktop(ewmh, children[i], dsk = cd);           /* case 2 */
                 }
                 else {
+                    if (isHidden)
+                        doMinimize = True;                                              /* case 4 */
                     if ((int)dsk > DESKTOPS-1)
                         xcb_ewmh_set_wm_desktop(ewmh, children[i], dsk = DESKTOPS-1);   /* case 8 */
                     if (dsk == cd) {


### PR DESCRIPTION
Fixed the "not 100% correct" _NET_WM_STATE_HIDDEN handling when restarting FrankenWM.

Now it checks if hidden property is set and moves the client to miniq, regardless of desktop number or map state. (Should have done it that way right from the beginning.)
