### PR TITLE
Optional _NET_WM_STRUT support

### DIFF
--- a/frankenwm.c
+++ b/frankenwm.c
@@ -1043,7 +1043,11 @@ void configurerequest(xcb_generic_event_t *e)
         if (ev->value_mask & XCB_CONFIG_WINDOW_Y) {
             int y = ev->y;
             if (c && c->type == ewmh->_NET_WM_WINDOW_TYPE_NORMAL) {
+#ifndef EWMH_TASKBAR
                 if (showpanel && TOP_PANEL && y < PANEL_HEIGHT)
+#else
+                if (y < wy)
+#endif /* EWMH_TASKBAR */
                      y = PANEL_HEIGHT;
             }
             v[i++] = y;

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -87,6 +87,15 @@ struct alien {
 };
 typedef struct alien alien;
 
+typedef struct
+{
+    uint16_t left, right, top, bottom;
+    uint16_t left_start_y, left_end_y;
+    uint16_t right_start_y, right_end_y;
+    uint16_t top_start_x, top_end_x;
+    uint16_t bottom_start_x, bottom_end_x;
+} strut_t;
+
 /* a key struct represents a combination of
  * mod      - a modifier mask
  * keysym   - and the key pressed
@@ -141,6 +150,7 @@ typedef struct client {
     unsigned int dim[2];
     int borderwidth;
     bool setfocus;
+    strut_t strut;
 } client;
 
 /* properties of each desktop
@@ -289,6 +299,9 @@ static desktop desktops[DESKTOPS];
 static lifo *miniq[DESKTOPS];
 static regex_t appruleregex[LENGTH(rules)];
 static xcb_key_symbols_t *keysyms;
+#ifdef EWMH_TASKBAR
+static strut_t gstrut;
+#endif /* EWMH_TASKBAR */
 
 /* events array
  * on receival of a new event, call the appropriate function to handle it
@@ -3276,6 +3289,25 @@ static inline void Update_EWMH_Taskbar_Properties(void)
         free(wins);
         DEBUGP("update _NET_CLIENT_LIST property (%d entries)\n", num);
     }
+}
+#endif /* EWMH_TASKBAR */
+
+
+#ifdef EWMH_TASKBAR
+static void Setup_Global_Strut(void)
+{
+}
+
+static void Cleanup_Global_Strut(void)
+{
+}
+
+static void Update_Global_Strut(void)
+{
+}
+
+static void Update_Client_Strut(client *c)
+{
 }
 #endif /* EWMH_TASKBAR */
 


### PR DESCRIPTION
Added optional (EWMH_TASKBAR = TRUE) strut support for top & bottom docks/panels.

TODO(?): Left and Right strut support.  (Needs some work to be done in the tile(); subfunctions.)
TODO(?): Struts for each desktop. (IMHO not needed, because most docks and utilities are sticky)
