### PR TITLE
clientmessage(_NET_CLOSE_WINDOW); calls now killclient(); instead removeclient();

### DIFF
--- a/frankenwm.c
+++ b/frankenwm.c
@@ -965,15 +965,23 @@ void clientmessage(xcb_generic_event_t *e)
                     setfullscreen(c, False);
                 break;
 
+                case _NET_WM_STATE_TOGGLE: {
+                    xcb_get_geometry_reply_t *wa = get_geometry(c->win);
+                    if (wa->x == 0
+                     && wa->y == 0
+                     && wa->width == screen->width_in_pixels
+                     && wa->height == screen->height_in_pixels) {
+                        setfullscreen(c, False);
+                        break;
+                    }
+                /* else fall thru to _NET_WM_STATE_ADD */
+                }
+
                 case _NET_WM_STATE_ADD:
                     xcb_raise_window(dis, c->win);
                     xcb_border_width(dis, c->win, 0);
                     xcb_move_resize(dis, c->win, 0, 0,
                         screen->width_in_pixels, screen->height_in_pixels);
-                break;
-
-                case _NET_WM_STATE_TOGGLE:
-/* TODO: */         setfullscreen(c, c->isfullscrn ? False : True);
                 break;
             }
         }

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -990,7 +990,7 @@ void clientmessage(xcb_generic_event_t *e)
             change_desktop(&(Arg){.i = ev->data.data32[0]});
         else {
             if (c && ev->type == ewmh->_NET_CLOSE_WINDOW)
-                removeclient(c);
+                killclient(c);
             else {
                 if (ev->type == ewmh->_NET_ACTIVE_WINDOW) {
                     if (c) {

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -960,9 +960,22 @@ void clientmessage(xcb_generic_event_t *e)
     if (c && ev->type == ewmh->_NET_WM_STATE) {
         if (((unsigned)ev->data.data32[1] == ewmh->_NET_WM_STATE_FULLSCREEN
           || (unsigned)ev->data.data32[2] == ewmh->_NET_WM_STATE_FULLSCREEN)) {
-            setfullscreen(c, (ev->data.data32[0] == 1 ||
-                             (ev->data.data32[0] == 2 &&
-                             !c->isfullscrn)));
+            switch (ev->data.data32[0]) {
+                case _NET_WM_STATE_REMOVE:
+                    setfullscreen(c, False);
+                break;
+
+                case _NET_WM_STATE_ADD:
+                    xcb_raise_window(dis, c->win);
+                    xcb_border_width(dis, c->win, 0);
+                    xcb_move_resize(dis, c->win, 0, 0,
+                        screen->width_in_pixels, screen->height_in_pixels);
+                break;
+
+                case _NET_WM_STATE_TOGGLE:
+/* TODO: */         setfullscreen(c, c->isfullscrn ? False : True);
+                break;
+            }
         }
         if (((unsigned)ev->data.data32[1] == ewmh->_NET_WM_STATE_HIDDEN
           || (unsigned)ev->data.data32[2] == ewmh->_NET_WM_STATE_HIDDEN)) {


### PR DESCRIPTION
Issue: if clientmessage(); receives _NET_CLOSE_WINDOW property, then at the moment it only unlinks the client from client list, instead close it.

Fix: clientmessage(); calls killclient(); instead removeclient();

Also added support for _NET_WM_STATE_FULLSCREEN.