### PR TITLE
Fullscreen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MANPREFIX = ${PREFIX}/share/man
 INCS = -I. -I${PREFIX}/include -I/usr/X11R6/include
 LIBS = -lc -lX11 `pkg-config --libs xcb xcb-aux xcb-icccm xcb-keysyms xcb-ewmh`
 
-CFLAGS   += -std=c99 -pedantic -Wall -Wextra ${INCS} ${CPPFLAGS}
+CFLAGS   += -std=c99 -pedantic -Wfatal-errors -Wall -Wextra ${INCS} ${CPPFLAGS}
 LDFLAGS  += ${LIBS}
 
 EXEC = ${WMNAME}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MANPREFIX = ${PREFIX}/share/man
 INCS = -I. -I${PREFIX}/include -I/usr/X11R6/include
 LIBS = -lc -lX11 `pkg-config --libs xcb xcb-aux xcb-icccm xcb-keysyms xcb-ewmh`
 
-CFLAGS   += -std=c99 -pedantic -Wfatal-errors -Wall -Wextra ${INCS} ${CPPFLAGS}
+CFLAGS   += -std=c99 -pedantic -Wall -Wextra ${INCS} ${CPPFLAGS}
 LDFLAGS  += ${LIBS}
 
 EXEC = ${WMNAME}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MANPREFIX = ${PREFIX}/share/man
 INCS = -I. -I${PREFIX}/include -I/usr/X11R6/include
 LIBS = -lc -lX11 `pkg-config --libs xcb xcb-aux xcb-icccm xcb-keysyms xcb-ewmh`
 
-CFLAGS   += -std=c99 -pedantic -Wall -Wextra -Os ${INCS} ${CPPFLAGS}
+CFLAGS   += -std=c99 -pedantic -Wall -Wextra ${INCS} ${CPPFLAGS}
 LDFLAGS  += ${LIBS}
 
 EXEC = ${WMNAME}

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -1291,40 +1291,18 @@ void clientmessage(xcb_generic_event_t *e)
     if (c && ev->type == ewmh->_NET_WM_STATE) {
         if (((unsigned)ev->data.data32[1] == ewmh->_NET_WM_STATE_FULLSCREEN
           || (unsigned)ev->data.data32[2] == ewmh->_NET_WM_STATE_FULLSCREEN)) {
-            setfullscreen(c, (ev->data.data32[0] == 1 ||
-                             (ev->data.data32[0] == 2 &&
-                             !c->isfullscreen)));
-#ifdef blah
-           switch (ev->data.data32[0]) {
-                case _NET_WM_STATE_REMOVE:
-                    c->isfullscreen = False;
-                    destroy_display(c);
-                break;
+            uint32_t mode = ev->data.data32[0];
 
-                case _NET_WM_STATE_TOGGLE: {
-                    xcb_get_geometry_reply_t *wa = get_geometry(c->win);
-                    if (wa->x == 0
-                     && wa->y == 0
-                     && wa->width == screen->width_in_pixels
-                     && wa->height == screen->height_in_pixels) {
-                        setmaximize(c, False);
-                        free(wa);
-                        break;
-                    }
-                    free(wa);
-                /* else fall thru to _NET_WM_STATE_ADD */
-                }
+            if (mode == _NET_WM_STATE_TOGGLE)
+                mode = (c->isfullscreen) ? _NET_WM_STATE_REMOVE : _NET_WM_STATE_ADD;
 
-                case _NET_WM_STATE_ADD:
-                    c->isfullscreen = True;
-                    create_display(c);
-                    xcb_border_width(dis, c->win, 0);
-                    xcb_lower_window(dis, c->win);
-                    xcb_move_resize(dis, c, 0, 0,
-                        screen->width_in_pixels, screen->height_in_pixels);
-                break;
+            if (mode == _NET_WM_STATE_REMOVE) {
+                destroy_display(c);
             }
-#endif /* blah */
+            else {  /* _NET_WM_STATE_ADD */
+                create_display(c);
+            }
+            setfullscreen(c, mode == _NET_WM_STATE_ADD);
         }
         if (((unsigned)ev->data.data32[1] == ewmh->_NET_WM_STATE_HIDDEN
           || (unsigned)ev->data.data32[2] == ewmh->_NET_WM_STATE_HIDDEN)) {

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -3472,10 +3472,17 @@ void update_current(client *newfocus)   // newfocus may be NULL
         }
     }
 
+    client *rl = NULL;
     for (client *c = M_HEAD; c; c = M_GETNEXT(c)) {
-        if (c->ismaximized)
+        if (c->ismaximized || c->isfloating || c->istransient || c->type != ewmh->_NET_WM_WINDOW_TYPE_NORMAL)
+            if (c == M_CURRENT) {
+                rl = c;
+                continue;
+            }
             xcb_raise_window(dis, c->win);
     }
+    if(rl)
+        xcb_raise_window(dis, rl->win);
 
     if (USE_SCRATCHPAD && showscratchpad && scrpd)
         xcb_raise_window(dis, scrpd->win);

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -1083,11 +1083,18 @@ static bool check_if_window_is_alien(xcb_window_t win, bool *isFloating, xcb_ato
                 if (type.atoms[i] == ewmh->_NET_WM_WINDOW_TYPE_DIALOG) {
                     if (isFloating)
                         *isFloating = True;
+                    isAlien = False;
                 }
                 else {
-                    unsigned int values[1] = {XCB_EVENT_MASK_PROPERTY_CHANGE}; 
-                    isAlien = True;
-                    xcb_change_window_attributes(dis, win, XCB_CW_EVENT_MASK, values);
+                    if (type.atoms[i] == ewmh->_NET_WM_WINDOW_TYPE_UTILITY) {
+                        /* I look at you, palemoon! */
+                        isAlien = False;
+                    }
+                    else {
+                        unsigned int values[1] = {XCB_EVENT_MASK_PROPERTY_CHANGE}; 
+                        xcb_change_window_attributes(dis, win, XCB_CW_EVENT_MASK, values);
+                        isAlien = True;
+                    }
                 }
             }
         }
@@ -2344,7 +2351,6 @@ fprintf(stderr, "valid\n");
     client *c = M_CURRENT;
     client *p = M_GETPREV(c);
     list   *l = c->link.parent;
-fprintf(stderr, "l=%lx, c=%lx, p=%lx\n", l, c, p);
     unlink_node(&c->link);
     insert_node_before(l, &p->link, &c->link);
     tile();


### PR DESCRIPTION
Okay, I think the new fullscreen code is ready for approval.
What did I do the last few days?
- change the client list functions to doubly linked.
- change the miniq fist to doubly linked.
Reason: Much easier handling.

- introduced 2 new internal layers: monitor and display.
Old:
Desktop 1 to Desktop X
       |
Clients

New:
Desktop 1 to Desktop X
       |
Monitor 1 to Monitor X
       |
Default Display to Display X
       |
  Clients

Reason: FrankenWM is now ready for MultiMonitor. (Sadly I own only one monitor)
Fullscreen clients create a new display and may have their own clients. As soon as the fullscreen mode is left, the display is destroyed and all clients are moved to the previous display.
(This idea is borrowed from one of my own "Fingerübungen" in writing an X11 wm.)

I know, it's quite a heavy code change, so take your time :).

Another important info: each display now saves the global values (master_size, mode, growth, etc)
directly in its internal structure. This makes save_desktop(); superfluous.




