### PR TITLE
Alternative VI or Screen alike commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MANPREFIX = ${PREFIX}/share/man
 INCS = -I. -I${PREFIX}/include -I/usr/X11R6/include
 LIBS = -lc -lX11 `pkg-config --libs xcb xcb-aux xcb-icccm xcb-keysyms xcb-ewmh`
 
-CFLAGS   += -std=c99 -pedantic -Wall -Wextra ${INCS} ${CPPFLAGS}
+CFLAGS   += -std=c99 -pedantic -Wfatal-errors -Wall -Wextra ${INCS} ${CPPFLAGS}
 LDFLAGS  += ${LIBS}
 
 EXEC = ${WMNAME}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MANPREFIX = ${PREFIX}/share/man
 INCS = -I. -I${PREFIX}/include -I/usr/X11R6/include
 LIBS = -lc -lX11 `pkg-config --libs xcb xcb-aux xcb-icccm xcb-keysyms xcb-ewmh`
 
-CFLAGS   += -std=c99 -pedantic -Wfatal-errors -Wall -Wextra ${INCS} ${CPPFLAGS}
+CFLAGS   += -std=c99 -pedantic -Wall -Wextra ${INCS} ${CPPFLAGS}
 LDFLAGS  += ${LIBS}
 
 EXEC = ${WMNAME}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MANPREFIX = ${PREFIX}/share/man
 INCS = -I. -I${PREFIX}/include -I/usr/X11R6/include
 LIBS = -lc -lX11 `pkg-config --libs xcb xcb-aux xcb-icccm xcb-keysyms xcb-ewmh`
 
-CFLAGS   += -std=c99 -pedantic -Wall -Wextra -Os ${INCS} ${CPPFLAGS}
+CFLAGS   += -std=c99 -pedantic -Wall -Wextra ${INCS} ${CPPFLAGS}
 LDFLAGS  += ${LIBS}
 
 EXEC = ${WMNAME}

--- a/config.def.h
+++ b/config.def.h
@@ -142,16 +142,16 @@ static key keys[] = {
     {  MOD4|SHIFT,       XK_c,          killclient,        {NULL}},
 
     /* desktop selection */
-       DESKTOPCHANGE(    XK_1,                             0)
-       DESKTOPCHANGE(    XK_2,                             1)
-       DESKTOPCHANGE(    XK_3,                             2)
-       DESKTOPCHANGE(    XK_4,                             3)
-       DESKTOPCHANGE(    XK_5,                             4)
-       DESKTOPCHANGE(    XK_6,                             5)
-       DESKTOPCHANGE(    XK_7,                             6)
-       DESKTOPCHANGE(    XK_8,                             7)
-       DESKTOPCHANGE(    XK_9,                             8)
-       DESKTOPCHANGE(    XK_0,                             9)
+       DESKTOPCHANGE(    XK_F1,                            0)
+       DESKTOPCHANGE(    XK_F2,                            1)
+       DESKTOPCHANGE(    XK_F3,                            2)
+       DESKTOPCHANGE(    XK_F4,                            3)
+       DESKTOPCHANGE(    XK_F5,                            4)
+       DESKTOPCHANGE(    XK_F6,                            5)
+       DESKTOPCHANGE(    XK_F7,                            6)
+       DESKTOPCHANGE(    XK_F8,                            7)
+       DESKTOPCHANGE(    XK_F9,                            8)
+       DESKTOPCHANGE(    XK_F0,                            9)
     /* toggle to last desktop */
     {  MOD4,             XK_Tab,        last_desktop,      {NULL}},
     /* jump to the next/previous desktop */

--- a/config.def.h
+++ b/config.def.h
@@ -37,6 +37,7 @@
 #define CLOSE_SCRATCHPAD True     /* close scratchpad on quit */
 #define SCRPDNAME       "scratchpad" /* the name of the scratchpad window */
 #define EWMH_TASKBAR    True      /* False if text (or no) panel/taskbar */
+#define SHOW_COMMANDWIN True      /* False if user wants to hide the command window */
 
 /*
  * EDIT THIS: applicaton specific rules

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -1952,7 +1952,7 @@ void keypress(xcb_generic_event_t *e)
     xcb_key_press_event_t *ev       = (xcb_key_press_event_t *)e;
     xcb_keysym_t           keysym   = xcb_get_keysym(ev->detail);
 
-    DEBUGP("xcb: keypress: code: %d mod: %d\n", ev->detail, ev->state);
+    DEBUGP("xcb: keypress: code=%d, mod=%d, keysym=%c\n", ev->detail, ev->state, keysym);
     if (cmdwin && cmdwin == ev->event) {
         if (keysym == XK_Escape) {
             update_current(M_CURRENT);
@@ -1963,9 +1963,9 @@ void keypress(xcb_generic_event_t *e)
              && NOMOD4MASK(CLEANMASK(keys[i].mod)) == NOMOD4MASK(CLEANMASK(ev->state))
              && keys[i].func) {
                 keys[i].func(&keys[i].arg);
-                if (cmdmode) {      /* still active? */
+                if (cmdmode)    /* still active? */
                     update_current(M_CURRENT);
-                }
+                break;
             }
         }
         return;
@@ -1974,8 +1974,10 @@ void keypress(xcb_generic_event_t *e)
         for (unsigned int i = 0; i < LENGTH(keys); i++) {
             if (keysym == keys[i].keysym &&
                 CLEANMASK(keys[i].mod) == CLEANMASK(ev->state) &&
-                keys[i].func)
+                keys[i].func) {
                     keys[i].func(&keys[i].arg);
+                    break;
+            }
         }
     }
 }

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -1291,40 +1291,18 @@ void clientmessage(xcb_generic_event_t *e)
     if (c && ev->type == ewmh->_NET_WM_STATE) {
         if (((unsigned)ev->data.data32[1] == ewmh->_NET_WM_STATE_FULLSCREEN
           || (unsigned)ev->data.data32[2] == ewmh->_NET_WM_STATE_FULLSCREEN)) {
-            setfullscreen(c, (ev->data.data32[0] == 1 ||
-                             (ev->data.data32[0] == 2 &&
-                             !c->isfullscreen)));
-#ifdef blah
-           switch (ev->data.data32[0]) {
-                case _NET_WM_STATE_REMOVE:
-                    c->isfullscreen = False;
-                    destroy_display(c);
-                break;
+            uint32_t mode = ev->data.data32[0];
 
-                case _NET_WM_STATE_TOGGLE: {
-                    xcb_get_geometry_reply_t *wa = get_geometry(c->win);
-                    if (wa->x == 0
-                     && wa->y == 0
-                     && wa->width == screen->width_in_pixels
-                     && wa->height == screen->height_in_pixels) {
-                        setmaximize(c, False);
-                        free(wa);
-                        break;
-                    }
-                    free(wa);
-                /* else fall thru to _NET_WM_STATE_ADD */
-                }
+            if (mode == _NET_WM_STATE_TOGGLE)
+                mode = (c->isfullscreen) ? _NET_WM_STATE_REMOVE : _NET_WM_STATE_ADD;
 
-                case _NET_WM_STATE_ADD:
-                    c->isfullscreen = True;
-                    create_display(c);
-                    xcb_border_width(dis, c->win, 0);
-                    xcb_lower_window(dis, c->win);
-                    xcb_move_resize(dis, c, 0, 0,
-                        screen->width_in_pixels, screen->height_in_pixels);
-                break;
+            if (mode == _NET_WM_STATE_REMOVE) {
+                destroy_display(c);
             }
-#endif /* blah */
+            else {  /* _NET_WM_STATE_ADD */
+                create_display(c);
+            }
+            setfullscreen(c, mode == _NET_WM_STATE_ADD);
         }
         if (((unsigned)ev->data.data32[1] == ewmh->_NET_WM_STATE_HIDDEN
           || (unsigned)ev->data.data32[2] == ewmh->_NET_WM_STATE_HIDDEN)) {

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -302,11 +302,12 @@ static void swap_master();
 static void switch_mode(const Arg *arg);
 static void tile(void);
 static void tilemize();
+static void togglecommandmode();
 static void togglepanel();
-static void unfloat_client(client *c);
 static void togglescratchpad();
-static void update_current(client *c);
+static void unfloat_client(client *c);
 static void unmapnotify(xcb_generic_event_t *e);
+static void update_current(client *c);
 static void xerror(xcb_generic_event_t *e);
 static alien *wintoalien(list *l, xcb_window_t win);
 static client *wintoclient(xcb_window_t w);
@@ -335,7 +336,7 @@ static strut_t gstrut;
 #endif /* EWMH_TASKBAR */
 
 /* variables */
-static bool running = true, show = true, showscratchpad = false;
+static bool running = true, show = true, showscratchpad = false, cmdmode = false;
 static int default_screen, previous_desktop, current_desktop_number, retval;
 static int borders;
 static unsigned int numlockmask, win_unfocus, win_focus, win_scratch;
@@ -3304,6 +3305,14 @@ void tilemize()
         return;
     unfloat_client(M_CURRENT);
     update_current(M_CURRENT);
+}
+
+void togglecommandmode()
+{
+    cmdmode = !cmdmode;
+    if (cmdmode) {
+        ;
+    }
 }
 
 /* toggle visibility state of the panel */

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -1083,11 +1083,18 @@ static bool check_if_window_is_alien(xcb_window_t win, bool *isFloating, xcb_ato
                 if (type.atoms[i] == ewmh->_NET_WM_WINDOW_TYPE_DIALOG) {
                     if (isFloating)
                         *isFloating = True;
+                    isAlien = False;
                 }
                 else {
-                    unsigned int values[1] = {XCB_EVENT_MASK_PROPERTY_CHANGE}; 
-                    isAlien = True;
-                    xcb_change_window_attributes(dis, win, XCB_CW_EVENT_MASK, values);
+                    if (type.atoms[i] == ewmh->_NET_WM_WINDOW_TYPE_UTILITY) {
+                        /* I look at you, palemoon! */
+                        isAlien = False;
+                    }
+                    else {
+                        unsigned int values[1] = {XCB_EVENT_MASK_PROPERTY_CHANGE}; 
+                        xcb_change_window_attributes(dis, win, XCB_CW_EVENT_MASK, values);
+                        isAlien = True;
+                    }
                 }
             }
         }
@@ -2344,7 +2351,6 @@ fprintf(stderr, "valid\n");
     client *c = M_CURRENT;
     client *p = M_GETPREV(c);
     list   *l = c->link.parent;
-fprintf(stderr, "l=%lx, c=%lx, p=%lx\n", l, c, p);
     unlink_node(&c->link);
     insert_node_before(l, &p->link, &c->link);
     tile();


### PR DESCRIPTION
If using FrankenWM remotely from Windows rdp client, I experienced problems with MOD4. Seems the client (or windows itself) does not forward this key to my linux xrdp. So, no FrankenWM commands were working.
This brought me to the brilliant idea, to add an alternative ctrl-a (or ctrl-b, w/e) invoked command.
Now we can press ctr-a, then the command key. For example: ctrl-a shift-return to spawn a terminal.
Soon I realized, the keys 0-9 also did not properly work. I remapped the change_desktop to F1-F10.
Then I had another brilliant idea, why not use 0-9 for optional command repetition. For example:
ctrl-a 3 shift-return spawns 3 terminals, or ctrl-a 4 j, (or ctrl-a 158 shift-c).

ctrl-a to invoke command-mode. if SHOW_COMMANDWIN = True, then a box is shown to indicate command mode. If SHOW_COMMANDWIN = False, then no box is shown. (power users may love this)
To cancel command mode, either press ctrl-a again, or press ESC, or change window focus.

ToDo: some commands simply do not make sense for command repetition. For example ctrl-a 5 F2.
A boolean flag in the keys structure to indicate if we shall repeat the command or not.

Final note: I realized too late this push depends on my previous fullscreen push. It should be easy to make a clean VIcmds push, if you do not approve my fullscreen push.