### PR TITLE
Switch to workspace & focus window on EWMH _NET_ACTIVE_WINDOW

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -19,6 +19,7 @@
 #define FOLLOW_MOUSE    False     /* Focus the window the mouse just entered */
 #define FOLLOW_WINDOW   False     /* Follow the window when moved to a different desktop */
 #define CLICK_TO_FOCUS  True      /* Focus an unfocused window when clicked */
+#define CHANGE_BORDER_COLOR    1  /* change window color on focus */
 #define BORDER_WIDTH    2         /* window border width */
 #define SCRATCH_WIDTH   1         /* scratch window border width, 0 to disable */
 #define FOCUS           "#cccccc" /* focused window border color   */


### PR DESCRIPTION
Switch to workspace & focus window on EWMH _NET_ACTIVE_WINDOW. Calling  `xcb_ewmh_request_change_active_window(ewmh, 0, winToActivated, 1, 0, currentWin);` from a client will cause winToActivated to become the active window 


Added option to disable changing border colors
Some applications want to set border colors based on certain factors. The new options ensures  Franken doesn't override these settings.