### PR TITLE
Allow custom man location and a few other things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ WMNAME  = frankenwm
 
 PREFIX ?= /usr/local
 BINDIR ?= ${PREFIX}/bin
-MANPREFIX = ${PREFIX}/share/man
+MANPREFIX ?= ${PREFIX}/share/man
 
-INCS = -I. -I${PREFIX}/include -I/usr/X11R6/include
+INCS = -I. -I. `pkg-config --cflags xcb xcb-aux xcb-icccm xcb-keysyms xcb-ewmh`
 LIBS = -lc -lX11 `pkg-config --libs xcb xcb-aux xcb-icccm xcb-keysyms xcb-ewmh`
 
 CFLAGS   += -std=c99 -pedantic -Wall -Wextra ${INCS} ${CPPFLAGS}

--- a/frankenwm.c
+++ b/frankenwm.c
@@ -10,6 +10,7 @@
 #include <signal.h>
 #include <regex.h>
 #include <sys/wait.h>
+#include <X11/Xlib.h>
 #include <X11/keysym.h>
 #include <xcb/xcb.h>
 #include <xcb/xcb_atom.h>
@@ -28,15 +29,6 @@
 #endif
 
 /* upstream compatility */
-#define True  true
-#define False false
-#define Mod1Mask     XCB_MOD_MASK_1
-#define Mod4Mask     XCB_MOD_MASK_4
-#define ShiftMask    XCB_MOD_MASK_SHIFT
-#define ControlMask  XCB_MOD_MASK_CONTROL
-#define Button1      XCB_BUTTON_INDEX_1
-#define Button2      XCB_BUTTON_INDEX_2
-#define Button3      XCB_BUTTON_INDEX_3
 #define XCB_MOVE_RESIZE XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT
 #define XCB_MOVE        XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y
 #define XCB_RESIZE      XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT
@@ -3582,7 +3574,6 @@ void xerror(xcb_generic_event_t *e)
 
 static void ungrab_focus(void)
 {
-#include <X11/Xlib.h>
     Display * dpy;
 
 


### PR DESCRIPTION
Hi,

FrankenWM is now an official package on NetBSD, https://pkgsrc.se/wm/frankenwm
My goal is to maintain the package, which was previously only available in Arch and Void.

Following NetBSD's recommendations to package maintainers, here are the patches required to build the WM.

-Allow custom man location and discovery of x11-base.
-Move include of Xlib.h into a reasonable place and do not re-define things that are already in Xlib.h

Please review them and consider merging these.
Authors: pin@NetBSD.org (myself) and Maya@NetBSD.org

Thx!