### PR TITLE
Allow user to choose which layouts to cycle over

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -14,7 +14,10 @@
 #define SHOW_PANEL      False     /* show panel by default on exec */
 #define TOP_PANEL       True      /* False means panel is on bottom */
 #define PANEL_HEIGHT    18        /* 0 for no space for panel, thus no panel */
-#define DEFAULT_MODE    TILE      /* TILE MONOCLE BSTACK GRID FIBONACCI EQUAL */
+/* Modes over which rotate_mode cycles.
+ * TILE MONOCLE BSTACK GRID FIBONACCI DUALSTACK EQUAL */
+#define CYCLE_MODES     (TILE|MONOCLE|BSTACK|GRID|FIBONACCI|DUALSTACK|EQUAL)
+#define DEFAULT_MODE    TILE      /* Any one of the stack modes */
 #define ATTACH_ASIDE    True      /* False means new window is master */
 #define FOLLOW_MOUSE    False     /* Focus the window the mouse just entered */
 #define FOLLOW_WINDOW   False     /* Follow the window when moved to a different desktop */


### PR DESCRIPTION
For people who use only a couple of favorite layouts, it might be worth to have one single keybinding to cycle through them. This allows choosing them with a new macro which defaults to all layouts for backwards compatibility.

    #define CYCLE_MODES (TILE|MONOCLE|BSTACK|GRID|FIBONACCI|DUALSTACK|EQUAL)

The keybindings to jump directly to one of the modes still work regardless of `CYCLE_MODES` value.