### PR TITLE
Fix and expand stdout and allow it independently of taskbar

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -32,11 +32,12 @@
 #define MONOCLE_BORDERS False     /* display borders in monocle mode */
 #define INVERT          False     /* use alternative modes by default */
 #define AUTOCENTER      True      /* automatically center windows floating by default */
+#define OUTPUT          False     /* write desktop info to stdout */
 #define OUTPUT_TITLE    False     /* output the title of the currently active window */
 #define USE_SCRATCHPAD  False     /* enable the scratchpad functionality */
 #define CLOSE_SCRATCHPAD True     /* close scratchpad on quit */
 #define SCRPDNAME       "scratchpad" /* the name of the scratchpad window */
-#define EWMH_TASKBAR    True      /* False if text (or no) panel/taskbar */
+#define EWMH_TASKBAR    True      /* undefine if text (or no) panel/taskbar */
 
 /*
  * EDIT THIS: applicaton specific rules


### PR DESCRIPTION
First, I believe stdout should be decoupled from the taskbar being defined or not. I, for one, opted to keep the taskbar defined but to enable stdout nonetheless. That is because if the taskbar is disabled, `wmctrl` does not work (this by itself deserves a separate fix too).

Then, the original code assumes `XCB_ICCCM_WM_ALL_HINTS` includes the urgency hint, but despite the name it does not, and thus no urgent window would ever be counted. This has been fixed.

Finally, I also added one more field to the the output; the number of minimized windows. This is a useful piece of information to expose.