### PR TITLE
Ability to run autostart script with a keypress (optional)

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -147,6 +147,7 @@ static key keys[] = {
     /* spawn terminal, dmenu, w/e you want to */
     {  MOD4|SHIFT,       XK_Return,     spawn,             {.com = termcmd}},
     {  MOD4,             XK_r,          spawn,             {.com = menucmd}},
+    {  MOD1,             XK_r,          spawn,             SHCMD("$HOME/.frankenwm/autostart.sh")},
     /* kill current window */
     {  MOD4|SHIFT,       XK_c,          killclient,        {NULL}},
 

--- a/config.def.h
+++ b/config.def.h
@@ -147,7 +147,8 @@ static key keys[] = {
     /* spawn terminal, dmenu, w/e you want to */
     {  MOD4|SHIFT,       XK_Return,     spawn,             {.com = termcmd}},
     {  MOD4,             XK_r,          spawn,             {.com = menucmd}},
-    {  MOD1,             XK_r,          spawn,             SHCMD("$HOME/.frankenwm/autostart.sh")},
+    /* uncomment to run autostart script */
+    /* {  MOD1,             XK_r,          spawn,             SHCMD("$HOME/.frankenwm/autostart.sh")}, */
     /* kill current window */
     {  MOD4|SHIFT,       XK_c,          killclient,        {NULL}},
 


### PR DESCRIPTION
When I come to use this WM, I find no patch that can help to autostart programs. It can be done by .xinitrc easily but people using graphical login managers will be helpless. 